### PR TITLE
Migrate to Robolectric 4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,10 +36,6 @@ allprojects {
     }
 }
 
-ext {
-    robolectricVersion = '3.8'
-}
-
 task clean(type: Delete) {
     delete rootProject.buildDir
 }

--- a/customtabs-example/build.gradle
+++ b/customtabs-example/build.gradle
@@ -34,7 +34,7 @@ android {
 dependencies {
     implementation project(':customtabs')
     implementation 'androidx.browser:browser:1.0.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-alpha2'
+    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'androidx.vectordrawable:vectordrawable-animated:1.0.0'
     implementation 'com.google.android.material:material:1.0.0'
 }

--- a/customtabs/build.gradle
+++ b/customtabs/build.gradle
@@ -49,15 +49,21 @@ android {
             consumerProguardFiles 'proguard-rules.pro'
         }
     }
+
+    testOptions {
+        unitTests.includeAndroidResources = true
+    }
 }
 
 dependencies {
-    api 'androidx.appcompat:appcompat:1.0.0'
+    api 'androidx.appcompat:appcompat:1.0.2'
     api 'androidx.browser:browser:1.0.0'
 
+    testImplementation 'androidx.test:core:1.0.0'
+    testImplementation("androidx.test.ext:junit:1.0.0")
     testImplementation 'junit:junit:4.12'
-    testImplementation "org.robolectric:robolectric:$rootProject.robolectricVersion"
-    testImplementation 'org.mockito:mockito-core:2.23.0'
+    testImplementation "org.robolectric:robolectric:4.0.2"
+    testImplementation 'org.mockito:mockito-core:2.23.4'
 }
 
 group = 'saschpe.android'

--- a/customtabs/src/test/java/saschpe/android/customtabs/CustomTabsPackageHelperTest.java
+++ b/customtabs/src/test/java/saschpe/android/customtabs/CustomTabsPackageHelperTest.java
@@ -18,22 +18,21 @@ package saschpe.android.customtabs;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
-import org.robolectric.annotation.Config;
 
 import java.util.List;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(RobolectricTestRunner.class)
-@Config(constants = BuildConfig.class, sdk = 27)
+@RunWith(AndroidJUnit4.class)
 public final class CustomTabsPackageHelperTest {
     @Test
     public void getPackageNameToUse_noMockingReturnsNull() {
         // Arrange, act
-        String packageName = CustomTabsPackageHelper.getPackageNameToUse(RuntimeEnvironment.application);
+        String packageName = CustomTabsPackageHelper.getPackageNameToUse(ApplicationProvider.getApplicationContext());
 
         // Assert
         assertNull(packageName);

--- a/customtabs/src/test/java/saschpe/android/customtabs/WebViewActivityTest.java
+++ b/customtabs/src/test/java/saschpe/android/customtabs/WebViewActivityTest.java
@@ -23,15 +23,14 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
-import org.robolectric.annotation.Config;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(RobolectricTestRunner.class)
+@RunWith(AndroidJUnit4.class)
 @Ignore
-@Config(constants = BuildConfig.class, sdk = 27)
 public final class WebViewActivityTest {
     private static final String TEST_URL = "http://sascha.peilicke.de";
     private static final String TEST_TITLE = "Sascha Peilicke";
@@ -40,7 +39,7 @@ public final class WebViewActivityTest {
     @Before
     public void setupActivity() {
         // Arrange
-        Intent intent = new Intent(RuntimeEnvironment.application, WebViewActivity.class)
+        Intent intent = new Intent(ApplicationProvider.getApplicationContext(), WebViewActivity.class)
                 .putExtra(WebViewActivity.EXTRA_TITLE, TEST_TITLE)
                 .putExtra(WebViewActivity.EXTRA_URL, TEST_URL);
 

--- a/customtabs/src/test/java/saschpe/android/customtabs/WebViewFallbackTest.java
+++ b/customtabs/src/test/java/saschpe/android/customtabs/WebViewFallbackTest.java
@@ -22,8 +22,8 @@ import android.net.Uri;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
@@ -31,8 +31,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(RobolectricTestRunner.class)
-@Config(constants = BuildConfig.class, sdk = 27)
+@RunWith(AndroidJUnit4.class)
 public final class WebViewFallbackTest {
     private static final String GITHUB_PAGE = "https://github.com/saschpe/android-customtabs/";
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,5 @@
 
 android.enableJetifier=true
 android.useAndroidX=true
+
+android.enableUnitTestBinaryResources=true


### PR DESCRIPTION
See the release notes [0] and the migration guide [1].

[0] http://robolectric.org/blog/2018/10/25/robolectric-4-0
[1] http://robolectric.org/migrating/#migrating-to-40